### PR TITLE
Move to validator 0.18+ (breaking change)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags: "*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get release version
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target x86_64-unknown-linux-gnu
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+
+  publish-crate:
+    name: Publish Crate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          dry-run: ${{ github.event_name != 'push' }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
     - name: Build without features
       run: make build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-contrib-rest"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Util types and functions for REST and webapp projects built on top of the Actix Web framework"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ exclude = [
 [dependencies]
 actix-http = "3.3"
 actix-web = "4.3"
-actix-web-validator = "5.0"
+actix-web-validator = "6.0"
 anyhow = "1.0"
 awc = { version = "3.1", features = ["rustls"] }
 futures-core = "0.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-validator = { version = "0.16", features = ["derive"] }
+validator = { version = ">=0.18.1", features = ["derive"] }
 
 server-env-config = { version = "0.1", optional = true }
 sqlx = { version = "0.7", features = ["runtime-async-std", "tls-native-tls"], optional = true }


### PR DESCRIPTION
- Solves #1.
- Add new GitHub Actions "Release" jobs.