### PR TITLE
Upgrades 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ futures-core = "0.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-validator = { version = ">=0.18.1", features = ["derive"] }
+validator = { version = "0.18.1", features = ["derive"] }
 
 server-env-config = { version = "0.1", optional = true }
-sqlx = { version = "0.7", features = ["runtime-async-std", "tls-native-tls"], optional = true }
+sqlx = { version = ">=0.7", features = ["runtime-async-std", "tls-native-tls"], optional = true }
 
 [features]
 sqlx = ["dep:sqlx", "dep:server-env-config"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-contrib-rest"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Util types and functions for REST and webapp projects built on top of the Actix Web framework"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Bump version 0.6.0.
- `validator` higher than 0.18.1 causes problems, pinning for now.
- Unpin `sqlx` 0.7.