### PR TITLE
v0.7: upgrade minimal dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get release version
         shell: bash
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: Swatinem/rust-cache@v2
     - name: Build without features
       run: make build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ actix-http = "3.3"
 actix-web = "4.3"
 actix-web-validator = "6.0"
 anyhow = "1.0"
-awc = { version = "3.1", features = ["rustls"] }
+awc = { version = "3.8", features = ["rustls"] }
 futures-core = "0.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ awc = { version = "3.8", features = ["rustls"] }
 futures-core = "0.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+thiserror = "2.0"
 validator = { version = "0.20", features = ["derive"] }
 
 server-env-config = { version = "0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-contrib-rest"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Util types and functions for REST and webapp projects built on top of the Actix Web framework"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,17 @@ exclude = [
 [dependencies]
 actix-http = "3.3"
 actix-web = "4.3"
-actix-web-validator = "6.0"
+actix-web-validator = "7.0"
 anyhow = "1.0"
 awc = { version = "3.8", features = ["rustls"] }
 futures-core = "0.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-validator = { version = "0.18.1", features = ["derive"] }
+validator = { version = "0.20", features = ["derive"] }
 
 server-env-config = { version = "0.1", optional = true }
-sqlx = { version = ">=0.7", features = ["runtime-async-std", "tls-native-tls"], optional = true }
+sqlx = { version = ">=0.8", features = ["runtime-async-std", "tls-native-tls"], optional = true }
 
 [features]
 sqlx = ["dep:sqlx", "dep:server-env-config"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It does include structs and methods to:
 - 📣 Properly serialize errors, with a JSON response explaining the reason.
 - 📄 Pagination and query search structs.
 - 🛢 Basic types for managing DB connections and transactions (`sqlx-postgres` feature).
-- ✅ Basic methods to easily deals with streams and integration tests.
+- ✅ Basic methods to easily deal with streams and integration tests.
 
 Check the 📖 docs at https://docs.rs/actix-contrib-rest/.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! - Properly serialize errors, with a JSON response explaining the reason.
 //! - Pagination and query search structs.
 //! - Basic types for managing DB connections and transactions (`sqlx-postgres` feature).
-//! - Basic methods to easily deals with streams and integration tests.
+//! - Basic methods to easily deal with streams and integration tests.
 //!
 //! > (❗️) This project is in a very early stage.
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -81,7 +81,7 @@ impl From<&ValidationErrors> for ValidationErrorPayload {
             error
                 .field_errors()
                 .iter()
-                .map(|(k, v)| (String::from(*k), (*v).clone())),
+                .map(|(k, v)| (String::from(k.clone()), (*v).clone())),
         );
         ValidationErrorPayload {
             code: Some("validation_error".to_owned()),


### PR DESCRIPTION
Upgrade minimal dependencies to make it work with latest versions of validation crates, SQLx and Actix:

- validation ~0.18.1~ ⟶ 0.20
- actix-web-validator ~6.0~ ⟶ 0.7
- sqlx ~0.7~ ⟶ 0.8
- thiserror ~1.0~ ⟶ 2.0